### PR TITLE
Add user deletion publishing

### DIFF
--- a/app/controllers.py
+++ b/app/controllers.py
@@ -1,6 +1,6 @@
 """Controllers for customer management using SQLAlchemy ORM."""
 
-from mq.publish import publish_user_update
+from mq.publish import publish_user_update, publish_user_delete
 from sqlalchemy.orm import Session
 from models import CustomerDB, OrderDB, ProductDB
 from schemas import Customer, Order, Product, OrderDetails
@@ -65,6 +65,8 @@ def delete_customer(db: Session, customer_id: str):
         return None
     db.delete(db_customer)
     db.commit()
+
+    publish_user_delete(customer_id)
     return db_customer
 
 

--- a/app/mq/publish.py
+++ b/app/mq/publish.py
@@ -24,3 +24,28 @@ def publish_user_update(user_id: int, data: dict):
 
     print(f" [x] Envoyé : {message}")
     connection.close()
+
+
+def publish_user_delete(user_id: int):
+    """Publie un message de suppression d'utilisateur."""
+    connection = pika.BlockingConnection(pika.ConnectionParameters('localhost'))
+    channel = connection.channel()
+
+    # Déclare l'exchange (type fanout = broadcast à toutes les queues)
+    channel.exchange_declare(exchange='users.sync', exchange_type='fanout')
+
+    # Message à envoyer
+    message = json.dumps({
+        "action": "delete",
+        "user_id": user_id
+    })
+
+    # Publie dans l'exchange
+    channel.basic_publish(
+        exchange='users.sync',
+        routing_key='',  # fanout ignore la routing_key
+        body=message
+    )
+
+    print(f" [x] Envoyé : {message}")
+    connection.close()


### PR DESCRIPTION
## Summary
- notify user deletion events through RabbitMQ
- invoke the new publisher when removing a customer

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6859a97c7d44832cb733f5fdbba80acf